### PR TITLE
writeFields method to be shared between create, update

### DIFF
--- a/Example/src/classes/ngForceController.cls
+++ b/Example/src/classes/ngForceController.cls
@@ -294,9 +294,34 @@ global class ngForceController{
         List<sObject> objs = new List<sObject>();
 
         Map<String, Object> incomingFieldJsonObject = null;
-        String error = writeFields(objType, obj, fields);
-        if (error != null) {
-            return error;
+        try {
+            incomingFieldJsonObject = (Map<String, Object>)JSON.deserializeUntyped(fields);
+        } catch (JSONException je) {
+            return '[{"message":"'+je.getMessage()+'","errorCode":"JSON_PARSER_ERROR"}]';
+        }
+        
+        try {
+            for(String row : incomingFieldJsonObject.keySet()){
+                Map<String,Object> current = (Map<String,Object>) incomingFieldJsonObject.get(row);
+                SObject obj = targetType.newSObject();
+                for(String property : current.keySet()) {
+                    if (targetFields.get(property).getDescribe().getType() == Schema.DisplayType.Date) {
+                        obj.put(property, Date.valueOf((String)current.get(property)));
+                    } else if (targetFields.get(property).getDescribe().getType() == Schema.DisplayType.Percent ||
+                           targetFields.get(property).getDescribe().getType() == Schema.DisplayType.Currency) {
+                        obj.put(property, String.valueOf(current.get(property)) == '' ? null : Decimal.valueOf((String)current.get(property)));
+                    } else if (targetFields.get(property).getDescribe().getType() == Schema.DisplayType.Double) {
+                        obj.put(property, String.valueOf(current.get(property)) == '' ? null : Double.valueOf(current.get(property)));
+                    } else if (targetFields.get(property).getDescribe().getType() == Schema.DisplayType.Integer) {
+                        obj.put(property, Integer.valueOf(current.get(property)));
+                    } else {
+                        obj.put(property, current.get(property));
+                    }
+                }
+                objs.add(obj);
+            }
+        } catch (SObjectException soe) {
+            return '[{"message":"'+soe.getMessage()+'","errorCode":"INVALID_FIELD"}]';
         }
         
         try {


### PR DESCRIPTION
The update method was having problems with dates passed in an object.  I looked between ngForce and remoteTK and was seeing that TK had this method as a private to be shared between anything writing fields.

I didn't do upsert yet because I haven't had a use case for it.

I also added some apex debug statements--purely for convenience.  At least for our org (public sites), it can be easier to turn on debug tracking on a user than it is to try to recreate whatever the users are doing to get the errors via the browser.  

I love you for making this!  
