### PR TITLE
adds else branch to handle base64 sObject fields

### DIFF
--- a/Example/src/classes/ngForceController.cls
+++ b/Example/src/classes/ngForceController.cls
@@ -68,6 +68,8 @@ global class ngForceController{
                         obj.put(key, svalue == '' ? null : Double.valueOf(svalue));
                     } else if (valueType == Schema.DisplayType.Integer) {
                         obj.put(key, Integer.valueOf(svalue));
+                    } else if (valueType == Schema.DisplayType.Base64) {
+                        obj.put(key, EncodingUtil.base64Decode(svalue.split(',')[1]));
                     } else {
                         obj.put(key, svalue);
                     }


### PR DESCRIPTION
Handling for blobs.  Lets you do create/update/etc on sobjects that are files (for example, Attachment).

This version assumes the data is encoded as DataURL, generally generated thusly:

reader.readAsDataURL(elem.files[0]);

where elem is the file input.

Be sure to also send up the filename so that salesforce can figure out what type it is by the extension, or set it using the ContentType field based on your app.
