### PR TITLE
strip off 'attribuates' before update/insert/etc

### DIFF
--- a/Example/src/classes/ngForceController.cls
+++ b/Example/src/classes/ngForceController.cls
@@ -36,6 +36,7 @@ global class ngForceController{
         Map<String, Object> fieldMap = null;
         try {
             fieldMap = (Map<String, Object>)JSON.deserializeUntyped(fields);
+            fieldMap.remove('attributes');
         } catch (JSONException je) {
             return makeError(je.getMessage(), 'JSON_PARSER_ERROR');
         }


### PR DESCRIPTION
Use case:  vfr.query an object, do some manipulation, then you want to put it with vfr.update.

If you put back what you pulled down, it's trying to write the 'attributes' part of the object, which of course doesn't exist in SF.

This removes it.  The apex map method 'remove' won't get upset if it doesn't exist, so this is safe.

I had the choice between doing this here in the class, but it could also be done with delete in the js component.  The only benefit there is that it would save a little bit of payload.
