### PR TITLE
Allow Name updates in sfr update function

### DIFF
--- a/Example/resource-bundles/ngForce.resource/ngForce/services/ngForce3.js
+++ b/Example/resource-bundles/ngForce.resource/ngForce/services/ngForce3.js
@@ -253,7 +253,7 @@ angular.module('ngForce', ['Scope.safeApply', 'restangular'])
         }
 
         // Remove fields we can't update.
-        var propsToIgnore = ['Id', 'Name', 'LastReferencedDate', 'LastModifiedById',
+        var propsToIgnore = ['Id', 'LastReferencedDate', 'LastModifiedById',
           'LastModifiedDate', 'LastViewedDate', 'SystemModstamp',
           'CreatedById', 'CreatedDate', 'IsDeleted'
         ];


### PR DESCRIPTION
'Name' is a property that can be updated when it's a Text field - was previously being stripped in the sfr update method.

Although updating an AutoNumber Name wouldn't be valid, updating a Text Name would be valid, and a common use case, so it should be left up to the developer to make sure they're not updating an AutoNumber name field, or handle it elegantly.
