### PR TITLE
handling unparseable remoting response

### DIFF
--- a/jsSrc/ngForce-visualForceRemoting.js
+++ b/jsSrc/ngForce-visualForceRemoting.js
@@ -90,7 +90,6 @@ angular.module('ngForce').provider('vfr', [function ($q, $rootScope) {
           try{ //because the result may contain unparseable characters
             result = JSON.parse(result);
           } catch (err){
-	    console.log('unparseable response from the server: ' + result);
 	    var errorResult = [{
 	       message: result,
 	       "errorCode": "NULL_RETURN"


### PR DESCRIPTION
I had an update call to a record that was already in an approval process.  The response contains [] and : in a few places, and the JSON.parse() couldn't.  I'm guessing that's not the only unparseable scenario.
