### PR TITLE
Handle remoting exceptions, and allow empty array results in vfr

### DIFF
--- a/jsSrc/subModules/ngForce-visualForceRemoting.js
+++ b/jsSrc/subModules/ngForce-visualForceRemoting.js
@@ -111,10 +111,12 @@ angular.module('ngForce')
 						if (typeof result !== 'object') {
 							result = JSON.parse(result);
 						}
-						if (Array.isArray(result) && result[0].message && result[0].errorCode) {
+						if (Array.isArray(result) && result.length !== 0 && result[0].message && result[0].errorCode) {
+							//Handle INVALID_SESSION_ID err coming back
 							deferred.reject(result);
 							$rootScope.$safeApply();
 						} else {
+							//result is an object, or has been parsed to one, or is an array
 							deferred.resolve(result);
 							$rootScope.$safeApply();
 						}

--- a/jsSrc/subModules/ngForce-visualForceRemoting.js
+++ b/jsSrc/subModules/ngForce-visualForceRemoting.js
@@ -120,6 +120,15 @@ angular.module('ngForce')
 							deferred.resolve(result);
 							$rootScope.$safeApply();
 						}
+					} else if (event && event.status === false) {
+						//exception or other unspecified error occurred while running the remote method
+						deferred.reject({
+							message: event.message,
+							method: event.method,
+							where: event.where,
+							errorCode: (event.type === 'exception' ? 'EXCEPTION' : 'UNSPECIFIED_ERROR'
+							$rootScope.$safeApply();
+						});
 					} else if (typeof nullok !== 'undefined' && nullok) {
 						deferred.resolve();
 						$rootScope.$safeApply();


### PR DESCRIPTION
Resolves #32 and #34 (see those issues for detailed descriptions):

**Summary:**
- When an empty array is returned intentionally by a remote action, resolve, instead of rejecting.
- When a remote action throws an exception, reject with useful information, instead of resolving