### PR TITLE
Fix bug - safeApply outside of error object!

### DIFF
--- a/jsSrc/subModules/ngForce-visualForceRemoting.js
+++ b/jsSrc/subModules/ngForce-visualForceRemoting.js
@@ -126,9 +126,9 @@ angular.module('ngForce')
 							message: event.message,
 							method: event.method,
 							where: event.where,
-							errorCode: (event.type === 'exception' ? 'EXCEPTION' : 'UNSPECIFIED_ERROR'
-							$rootScope.$safeApply();
+							errorCode: (event.type === 'exception' ? 'EXCEPTION' : 'UNSPECIFIED_ERROR')
 						});
+						$rootScope.$safeApply();
 					} else if (typeof nullok !== 'undefined' && nullok) {
 						deferred.resolve();
 						$rootScope.$safeApply();


### PR DESCRIPTION
Fixes a bug in my last PR #35 - was doing $rootScope.$safeApply() _inside_ exception object creation - which of course causes the object to be invalid, and everything to explode :D Had this in local, but had neglected to commit before opening the PR