### PR TITLE
Fix issue 40 -- move standardOpts outside of return object

### DIFF
--- a/jsSrc/subModules/ngForce-visualForceRemoting.js
+++ b/jsSrc/subModules/ngForce-visualForceRemoting.js
@@ -16,24 +16,24 @@
  */
 angular.module('ngForce')
 	.provider('vfr', function() {
+		/**
+		 * Object contains the two standard fields needed by the .send method: escape and timeout.
+		 * escape: Should the result be escape. default to false.
+		 * timeout: set the timeout for visualforce to respond.
+		 * @type {Object}
+		 */
+		var standardOpts = {
+			escape: false,
+			timeout: 10000
+		};
 
 		// Force shutdown the VFR provider / factory if VisualForce is not already an object on window.
 		if (typeof Visualforce != 'object') {
 			throw new Error('Visualforce is not available as an object! Did you forget to include the ngForce component?');
 		}
 		var vfRemote = {};
-		var standardOpts = {
-			escape: false,
-			timeout: 10000
-		};
 
 		return {
-			/**
-			 * Object contains the two standard fields needed by the .send method: escape and timeout.
-			 * escape: Should the result be escape. default to false.
-			 * timeout: set the timeout for visualforce to respond.
-			 * @type {Object}
-			 */
 			setStandardOptions: function(newOptions) {
 				if (newOptions && typeof newOptions !== 'object') {
 					throw new Error('standardOptions must be an object');

--- a/jsSrc/subModules/ngForce-visualForceRemoting.js
+++ b/jsSrc/subModules/ngForce-visualForceRemoting.js
@@ -22,6 +22,10 @@ angular.module('ngForce')
 			throw new Error('Visualforce is not available as an object! Did you forget to include the ngForce component?');
 		}
 		var vfRemote = {};
+		var standardOpts = {
+			escape: false,
+			timeout: 10000
+		};
 
 		return {
 			/**
@@ -30,10 +34,6 @@ angular.module('ngForce')
 			 * timeout: set the timeout for visualforce to respond.
 			 * @type {Object}
 			 */
-			var standardOpts = {
-				escape: false,
-				timeout: 10000
-			},
 			setStandardOptions: function(newOptions) {
 				if (newOptions && typeof newOptions !== 'object') {
 					throw new Error('standardOptions must be an object');


### PR DESCRIPTION
Master does not currently build.  This fixes it, as suggested here: https://github.com/noeticpenguin/ngForce/issues/40#issuecomment-204350626